### PR TITLE
Implement localStorage points persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,9 @@ Welcome to Cosmic Ascendancy: The Path to Prosperity, an exciting sci-fi increme
 - **Version Control:** GitHub
 - **Hosting:** GitHub Pages
 - **Release Date:** TBD
+
+## Saving Progress
+
+The game automatically stores your points using the browser's `localStorage`.
+Reloading the page restores the last saved value with `localStorage.getItem('points')`.
+Each time points increase, the updated total is saved for future sessions.

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,11 @@
-// Define a central point variable
-let points = 1;
+// Restore saved points or start at 1
+const storedPoints = localStorage.getItem("points");
+let points = storedPoints !== null ? parseInt(storedPoints, 10) : 1;
+
+function incrementPoints(amount = 1) {
+  points += amount;
+  localStorage.setItem("points", points);
+}
 
 document.addEventListener("DOMContentLoaded", function () {
   const gameContainer = document.getElementById("game-container");


### PR DESCRIPTION
## Summary
- restore saved points from localStorage
- save points whenever they increase
- document progress saving in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840ecd3e8408327b1ed42ab9db83f23